### PR TITLE
Fix tifffile 2021.3.31 imagecodecs requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.7
     - pip
   run:
-    - python >=3.6
+    - python >=3.7
     - numpy >=1.15.1
     - imagecodecs >=2021.3.31
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python >=3.6
     - numpy >=1.15.1
-    - imagecodecs
+    - imagecodecs >=2021.3.31
 
 test:
   imports:


### PR DESCRIPTION
tifffile 2021.3.31 requires imagecodecs 2021.3.31 - see https://github.com/conda-forge/tifffile-feedstock/pull/74

@cjmartian, @chenghlee, this would also need patching the repodata.