### PR TITLE
Update tifffile to version 2021.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python >=3.7
     - numpy >=1.15.1
     # Extras require:
-    - imagecodecs >=2021.4.28
+    - imagecodecs >=2021.7.30
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 2
+  skip: True  # [py<37]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -22,7 +23,7 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools
     - wheel
@@ -36,6 +37,7 @@ test:
   imports:
     - tifffile
   requires:
+    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tifffile" %}
-{% set version = "2021.7.2" %}
-{% set sha256 = "17fc5ca901f7d7b827a16e4695668e6120319324efe6d1333258397d8a71dedb" %}
+{% set version = "2021.11.2" %}
+{% set sha256 = "153e31fa1d892f482fabb2ae9f2561fa429ee42d01a6f67e58cee13637d9285b" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 2
-  skip: True  # [py<37]
+  # there is a missing dependency for s390x imagecodecs version >=2021.4.28 
+  skip: True  # [py<37 or s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   # there is a missing dependency for s390x imagecodecs version >=2021.4.28 
   skip: True  # [py<37 or s390x]
   noarch: python


### PR DESCRIPTION
  tifffile 2021.11.2
1. check the upstream
    https://github.com/cgohlke/tifffile/tree/v2021.11.2

2. check the pinnings
    https://github.com/cgohlke/tifffile/blob/v2021.11.2/setup.py
    https://github.com/cgohlke/tifffile/blob/v2021.11.2/MANIFEST.in

3. check the changelogs
    https://github.com/cgohlke/tifffile/blob/v2021.11.2/CHANGES.rst

    There were no significant breaking changes mentioned in the changelog

4. additional research
    
    https://github.com/conda-forge/tifffile-feedstock/issues

    Currently there are no open issues in conda-forge

5. verify dev_url
    https://github.com/cgohlke/tifffile

6. verify doc_url
    https://github.com/cgohlke/tifffile/blob/master/README.rst

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `tifffile` package version `2021.11.2` the folowing
command was used:
`conda build tifffile-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `tifffile` to version `2021.11.2`
