### PR TITLE
tifffile 2024.12.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "tifffile" %}
-{% set version = "2023.4.12" %}
-{% set sha256 = "2fa99f9890caab919d932a0acaa9d0f5843dc2ef3594e212963932e20713badd" %}
+{% set version = "2024.12.12" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c38e929bf74c04b6c8708d87f16b32c85c6d7c2514b99559ea3db8003ba4edda
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
   entry_points:
     - tifffile = tifffile:main
@@ -28,11 +27,12 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.19.2
-    # Extras require:
-    - imagecodecs >=2023.1.23
+    - numpy
   run_constrained:
     - matplotlib-base >=3.3
+    # imagecodecs shouldn't be used in run as it will become a circular dependency
+    - imagecodecs >=2023.8.12 # extra:codecs
+    - zarr <3 # extra:zarr
 
 test:
   imports:
@@ -41,6 +41,8 @@ test:
     - pip
   commands:
     - pip check
+    - tifffile --help
+    - tiff2fsspec --help
 
 about:
   home: https://github.com/cgohlke/tifffile


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6543](https://anaconda.atlassian.net/browse/PKG-6543)
- [Upstream repo](https://github.com/cgohlke/tifffile/tree/v2024.12.12)
- release-diff: https://github.com/cgohlke/tifffile/compare/v2023.4.12...v2024.12.12
- changelog: https://github.com/cgohlke/tifffile/blob/master/CHANGES.rst
- license: https://github.com/cgohlke/tifffile/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/cgohlke/tifffile/blob/v2024.12.12/setup.py


### Explanation of changes:

- Skip py<310
- Move optional dependency `imagecodecs >=2023.1.23` from `run` to `run_constrained` because `imagecodecs` uses `tifffile` for tests and incompatible versions failed.
- Add `zarr <3` to `run_constrained`
- Add more test commands

### Notes:

- imagecodecs 2024.9.22 requires `tifffile` for tests https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/17

[PKG-6543]: https://anaconda.atlassian.net/browse/PKG-6543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ