### PR TITLE
tifffile 2025.2.18 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run_constrained:
     - matplotlib-base >=3.10
     # imagecodecs shouldn't be used in run as it will become a circular dependency
-    - imagecodecs >=2023.8.12 # extra:codecs
+    - imagecodecs >=2024.12.30 # extra:codecs
     - zarr <3 # extra:zarr
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tifffile" %}
-{% set version = "2024.12.12" %}
+{% set version = "2025.2.18" %}
 
 package:
   name: {{ name|lower }}
@@ -29,7 +29,7 @@ requirements:
     - python
     - numpy
   run_constrained:
-    - matplotlib-base >=3.3
+    - matplotlib-base >=3.10
     # imagecodecs shouldn't be used in run as it will become a circular dependency
     - imagecodecs >=2023.8.12 # extra:codecs
     - zarr <3 # extra:zarr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c38e929bf74c04b6c8708d87f16b32c85c6d7c2514b99559ea3db8003ba4edda
+  sha256: 8d731789e691b468746c1615d989bc550ac93cf753e9210865222e90a5a95d11
 
 build:
   number: 0


### PR DESCRIPTION
tifffile 2025.2.18 

**Destination channel:** Defaults

### Links

- [PKG-6390]
- dev_url:        https://github.com/cgohlke/tifffile/tree/v2025.2.18
- conda_forge:    https://github.com/conda-forge/tifffile-feedstock
- pypi:           https://pypi.org/project/tifffile/2025.2.18
- pypi inspector: https://inspector.pypi.io/project/tifffile/2025.2.18

### Explanation of changes:

- new version number


[PKG-6390]: https://anaconda.atlassian.net/browse/PKG-6390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ